### PR TITLE
Fix expect.js requirement and default reporter in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,39 @@ Default value: `['Chrome']`
 
 List of browsers to test with.
 
+#### options.reporter
+
+Type: `String`
+Default value: `Spec`
+
+Mocha reporter to use
+
+#### options.baseUrl
+
+Type: `String`
+Default value: ``
+
+#### options.args
+
+Type: `Array`
+Default value: `null`
+
+Example of full config
+
+```js
+grunt.initConfig({
+  mochaProtractor: {
+    options: {
+      browsers: ['Chrome', 'Firefox'],
+      reporter: 'Spec',
+      baseUrl: 'https://develop.mywebsite.local',
+      args: '--ignore-certificate-errors'
+    },
+    files: ['test/e2e/*.js']0
+  },
+})
+```
+
 ## Contributing
 
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,11 +12,19 @@ var webdriver = require('selenium-webdriver'),
     Module = require('module');
 
 module.exports = function (grunt, fileGroup, browser, options, next) {
+  var capabilities = webdriver.Capabilities[browser.toLowerCase()]();
+  if (browser === 'Chrome' && options.args) {
+    options.args.forEach(function (arg) {
+      capabilities.set("chrome.switches", arg);
+    })
+  }
+
   var driver = new webdriver.Builder().
       usingServer('http://localhost:4444/wd/hub').
-      withCapabilities(webdriver.Capabilities[browser.toLowerCase()]()).build();
+      withCapabilities(capabilities).build();
+
   driver.manage().timeouts().setScriptTimeout(10000);
-  var ptor = protractor.wrapDriver(driver);
+  var ptor = protractor.wrapDriver(driver, options.baseUrl);
 
   var finish = function(err) {
     driver.quit().then(function() { next(err); });

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   "dependencies": {
     "mocha": "~1.12.0",
     "selenium-webdriver": "~2.35.1",
-    "protractor": "~0.7.0"
+    "protractor": "~0.7.0",
+    "expect.js": "~0.2.0"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.6.0",
-    "expect.js": "~0.2.0"
+    "grunt-contrib-jshint": "~0.6.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"

--- a/tasks/mocha-protractor.js
+++ b/tasks/mocha-protractor.js
@@ -18,7 +18,10 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('mochaProtractor', 'The best Grunt plugin ever.', function() {
     var files = this.files,
         options = this.options({
-          browsers: ['Chrome']
+          browsers: ['Chrome'],
+          reporter: 'Spec',
+          baseUrl : '',
+          args: null
         });
 
     // wrap reporter


### PR DESCRIPTION
- expect.js is unavailable if not installed as a non dev dependency
- reporter is mandatory so I added a Spec one as default
- added baseUrl option
- added args option (only for chrome)
- update README.md
