### PR TITLE
Add ability to pass job annotation params to Saucelabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,16 @@ Default value: `['Chrome']`
 
 List of browsers to test with.
 
-To test with SauceLabs the browser can also be specified as an object.
+To test with SauceLabs the browser can also be specified as an object. You can also add session name, tags, and build.
 
 ```js
 grunt.initConfig({
   mochaProtractor: {
     options: {
       reporter: 'Spec',
+      sauceSession: 'my example name',      // optional
+      sauceBuild: 'build-1337',             // optional
+      sauceTags: ['tag1', 'tag2', 'tag3'],  // optional
       browsers: [{
         base: 'SauceLabs',
         browserName: 'Firefox',
@@ -109,6 +112,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+* v0.6.0 - add saucelabs job annotations params (https://saucelabs.com/docs/additional-config#metadata).
 * v0.5.2 - update dependencies.
 * v0.5.1 - add ability to override timeouts (thanks chriscantu).
 * v0.5.0 - add seleniumUrl param, fixed "max call stack" error (thanks nowells).

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -46,6 +46,8 @@ module.exports = function (grunt, fileGroup, browser, options, next) {
       username: options.sauceUsername,
       accessKey: options.sauceAccessKey,
       name: options.sauceSession,
+      build: options.sauceBuild,
+      tags: options.sauceTags,
       browserName: browser.browserName,
       platform: browser.platform,
       version: browser.version,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-mocha-protractor",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Run e2e angular tests with webdriver.",
   "homepage": "https://github.com/noblesamurai/grunt-mocha-protractor",
   "bugs": "https://github.com/noblesamurai/grunt-mocha-protractor/issues",


### PR DESCRIPTION
### v0.6.0

If you merge this in, make sure you push the new tag.

---

Saucelabs allows you to pass in job annotation parameters for session `name`, `build`, and `tags`. See screenshot below:
![screen shot 2014-03-12 at 3 25 36 pm](https://f.cloud.github.com/assets/1276103/2401988/97b8a054-aa1c-11e3-920b-ea66cbc23053.png)

You can pass in these values to selenium as described here: https://saucelabs.com/docs/additional-config#metadata

We're running tests on Saucelabs at work, and it would be nice to have this functionality available via `grunt-mocha-protractor`. I manually verified that it correctly passes these values to Saucelabs. The screenshot above was from the manual verification.

Thanks for your work with grunt-mocha-protractor, Andrew!
